### PR TITLE
Discuss social nature of code review in the "good practices" part

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -270,19 +270,10 @@ But in research this is a whole other level of heterogeneity.
 
 :::
 
-### Finding reviewers {background-color="grey"}
+### Other challenges {background-color="grey"}
 
-What about "lone coders"?
-
-### Lack of guidelines {background-color="grey"}
-
-https://dev-review.readthedocs.io/
-
-https://osc-delft.github.io/posts/2021/09/03/Research-Code-Review/
-
-https://www.djmannion.net/code_review/
-
-https://blog.hpc.qmul.ac.uk/code_review_whri.html
+- Finding reviewers
+- Finding guidance or mentors
 
 ### Part 3: Code review good practices {background-color="green" transition="zoom"}
 

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -274,27 +274,6 @@ But in research this is a whole other level of heterogeneity.
 
 What about "lone coders"?
 
-### Bad experiences {background-color="grey"}
-
-Code review can lead both to inclusion and exclusion.
-
-Dual nature: both **technical** and **social** practice.
-
-### Bad experiences {background-color="grey"}
-
--   Irrelevant feedback.
--   Petty arguments decoupled from overall scientific goal.
--   Power struggles.
-
-These must be and active effort to keep these under control. Similar
-to technical debt.
-
-. . .
-
-> A bad reviewer tries to force their preference on you. A good code
-> reviewer makes your code confrom to certain principles, but not
-> opinion. (*Quote from survey participant from Greiler, 2016*)
-
 ### Lack of guidelines {background-color="grey"}
 
 https://dev-review.readthedocs.io/
@@ -518,6 +497,16 @@ Feedback can be hard to stomach
 *I think this function's purpose would be much clearer if it was given
 a more explicit name.. perhaps `apply_bwd_transform`?*
 
+### Code review is both **technical** and **social**
+
+Code reviews can drive both inclusion and exclusion.
+
+. . .
+
+> A bad reviewer tries to force their preference on you. A good code
+> reviewer makes your code confrom to certain principles, but not
+> opinion. (*Quote from survey participant from Greiler, 2016*)
+
 ### Define (and refine) a policy {background-color="green"}
 
 -   Well defined process.
@@ -525,6 +514,18 @@ a more explicit name.. perhaps `apply_bwd_transform`?*
 -   Moderator(s).
 -   Code of conduct.
 -   Conflict resolution.
+
+::: notes
+
+A code reviwe is a conversation, potentially involving more than 2 people. as
+any converstaion it can shift to irrelevant topics, unproductive arguments or
+power struggles.
+
+A clear policy including moderation and conflict resolution procedures can
+guard against these.
+
+:::
+
 
 ### A culture of openess and collaboration
 

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -75,11 +75,11 @@ Practices* (McLeod et al, 2017)
 
 *Code review by and for scientists* (Petre & Wilson, 2014)
 
-### Part 2
+### Part 1 {background-color="#002147" transition="zoom"}
 
 <h3>Challenges of code reviews</h3>
 
-### Code review for software quality
+### Code review for software quality {background-color="#002147"}
 
 1.  Defects
 2.  Code improvements
@@ -98,7 +98,7 @@ complying to a naming scheme, identifying code smells.
 
 :::
 
-### Code review for software quality
+### Code review for software quality {background-color="#002147"}
 
 ![(Bachelli & Bird, 13)](img/defects-improvement-bachelli-bird2013.png)
 
@@ -112,7 +112,7 @@ But code review is clearly effective for improving code.
 
 :::
 
-### Code reviews for understandability
+### Code reviews for understandability {background-color="#002147"}
 
 More often than not source code is the only available form of documentation.
 
@@ -133,7 +133,7 @@ it very attractive for research software.
 
 :::
 
-### Code reviews for team awareness
+### Code reviews for team awareness {background-color="#002147"}
 
 -   Continuous knowledge exchange.
 -   Enhanced collaboration.
@@ -157,7 +157,7 @@ Code review had an indicrect impact: people talk to each other more.
 
 :::
 
-### Code reviews for knowledge transfer
+### Code reviews for knowledge transfer {background-color="#002147"}
 
 Code review is peer learning.
 

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -188,7 +188,7 @@ Dataclasses
 
 :::
 
-### Code review is challenging
+### Part 2: Challenges {background-color="grey" transition="zoom"}
 
 A lot of good practices around...
 
@@ -204,7 +204,7 @@ this is not happening.
 
 :::
 
-### Code review is time and energy
+### Code review is time and energy {background-color="grey"}
 
 Two complementary courses of actions:
 
@@ -230,7 +230,7 @@ your code.
 
 :::
 
-### Being protective about code
+### Being protective about code {background-color="grey"}
 
 1. There can be some unhealthy competition going on.
 2. A large number of researchers feel shy about their coding practices:
@@ -253,7 +253,7 @@ not used to share code. Code review can help turn the tide.
 
 :::
 
-### Strong heterogeneity among team members
+### Strong heterogeneity among team members {background-color="grey"}
 
 -   Experience.
 -   Skills (*e.g.* programming languages).
@@ -270,17 +270,17 @@ But in research this is a whole other level of heterogeneity.
 
 :::
 
-### Finding reviewers
+### Finding reviewers {background-color="grey"}
 
 What about "lone coders"?
 
-### Bad experiences
+### Bad experiences {background-color="grey"}
 
 Code review can lead both to inclusion and exclusion.
 
 Dual nature: both **technical** and **social** practice.
 
-### Bad experiences
+### Bad experiences {background-color="grey"}
 
 -   Irrelevant feedback.
 -   Petty arguments decoupled from overall scientific goal.
@@ -295,7 +295,7 @@ to technical debt.
 > reviewer makes your code confrom to certain principles, but not
 > opinion. (*Quote from survey participant from Greiler, 2016*)
 
-### Lack of guidelines
+### Lack of guidelines {background-color="grey"}
 
 https://dev-review.readthedocs.io/
 

--- a/slides/slides.md
+++ b/slides/slides.md
@@ -305,11 +305,7 @@ https://www.djmannion.net/code_review/
 
 https://blog.hpc.qmul.ac.uk/code_review_whri.html
 
-### Part 3
-
-<h3>Code reviews done right</h3>
-
-### Code review good practices
+### Part 3: Code review good practices {background-color="green" transition="zoom"}
 
 A lot of the good practices from software engineering industry are applicable,
 **with a pinch of salt**.
@@ -321,7 +317,7 @@ observations/experimentation in a research context.
 
 :::
 
-### Short meetings
+### Short meetings {background-color="green"}
 
 3 times 30' instead of one time 90'
 
@@ -331,7 +327,7 @@ observations/experimentation in a research context.
 
 Remember that software isn't the primary driver.
 
-### Engage with the review
+### Engage with the review {background-color="green"}
 
 Avoid "comfort mode" at all costs!
 
@@ -344,7 +340,7 @@ Avoid "comfort mode" at all costs!
 - Reviewers should **never stop questionning** and trying to understand the code
 - Authors should **give reviewers opportunities to interject**.
 
-### The author's part
+### The author's part {background-color="green"}
 
 -   Choose a small piece of code.
 -   Provide a description of the purpose and structure of the code.
@@ -364,7 +360,7 @@ entirely responsible for the review success, but can definetely make it fail.
 :::
 
 
-### Let authors specify the feedback they are after
+### Let authors specify the feedback they are after {background-color="green"}
 
 *I'm not happy with this loop*
 
@@ -392,7 +388,7 @@ Feedback is likely to be more targeted and impactful.
 
 :::
 
-### Define (and enforce) a scope
+### Define (and enforce) a scope {background-color="green"}
 
 Example default scope: understandability
 
@@ -413,7 +409,7 @@ Another way to foster relevant feedback and discussions is to define a scope.
 
 :::
 
-### Whether "it works" or not is irrelevant
+### Whether "it works" or not is irrelevant {background-color="green"}
 
 - Code review is not an evaluation of a finished product.
 - It is more rewarding to look at code that is WIP.
@@ -426,7 +422,7 @@ Another way to foster relevant feedback and discussions is to define a scope.
 :::
 
 
-### Make it formal -- but safe
+### Make it formal -- but safe {background-color="green"}
 
 Code review is more effective with a clear process (formal)
 
@@ -436,7 +432,7 @@ Code review meetings *must* remain inclusives and supporting spaces.
 **It's about creating an environment where people feel confident about
 discussing their code to each other.**
 
-### Overheard in the next meeting room
+### Overheard in the next meeting room {background-color="#C72A3D"}
 
 Author: *This loop I wrote looks too complicated to me.*
 
@@ -465,14 +461,14 @@ Reviewer: *Alhtough you could also do the same thing with `sed`.*
 
 Author (looking frustrated): *I have no idea what you're talking about.*
 
-### All feedback isn't helpful
+### All feedback isn't helpful {background-color="green"}
 
 ...at least for now.
 
 Reviewers with more programming experience/enthusiasm must be
 careful not to overwhelm beginners.
 
-### Use a checklist
+### Use a checklist {background-color="green"}
 
 -   [ ] Poor formatting.
 -   [ ] Dead code.
@@ -496,7 +492,7 @@ Start with the easy checks.
 
 :::
 
-### Critique the code, not the programmer
+### Critique the code, not the programmer {background-color="#C72A3D"}
 
 *You clearly made little effort in naming things&#x2026;*
 
@@ -504,13 +500,13 @@ Start with the easy checks.
 
 *I think this name is misleading*
 
-:::
+::: notes
 
 Feedback can be hard to stomach
 
 :::
 
-### Giving feedback is not trivial
+### Giving feedback is not trivial {background-color="green"}
 
 1.  Own you opinions.
 2.  Make it about the code.
@@ -522,7 +518,7 @@ Feedback can be hard to stomach
 *I think this function's purpose would be much clearer if it was given
 a more explicit name.. perhaps `apply_bwd_transform`?*
 
-### Define (and refine) a policy
+### Define (and refine) a policy {background-color="green"}
 
 -   Well defined process.
 -   Default scope.


### PR DESCRIPTION
_This branch is based on #9 and diff from main includes its commits. Diff will be easier to view after #9 is merged._

This moves the two slides on "bad experiences" from the challenges section down to the best practice section.

This reduces the size of the section on challenges whilst giving more room to address social good practices in the next section